### PR TITLE
Fix loop condition on property_folders

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,9 @@
     file_type: file
     hidden: yes
     recurse: no
-  with_items: "{{ property_folders }}"
+  with_items: "{{ property_folders|default([]) }}"
   register: props
-  when: property_folders is defined and property_folders | trim | length > 0
+  when: item is defined
   delegate_to: localhost
 
 - name: Load variables


### PR DESCRIPTION
The with_items expressions is evaluated before the when expression.
Because of this, the with_items expressions would error out if
property_folders is not defined. The workaround here is to default to
empty iterator, and make the when conditional on the item being defined.